### PR TITLE
rename service accounts and use krb_principals

### DIFF
--- a/roles/koji-hub/tasks/main.yml
+++ b/roles/koji-hub/tasks/main.yml
@@ -186,19 +186,23 @@
 - name: Configure the kojira user account
   koji_user:
     koji: kojidev
-    name: koji/kojira
+    name: kojira
     state: enabled
     permissions:
     - repo
+    krb_principals:
+    - koji/kojira@KOJIDEV.EXAMPLE.COM
   become: no
 
 - name: Configure the garbagecollector user account
   koji_user:
     koji: kojidev
-    name: koji/garbagecollector
+    name: garbagecollector
     state: enabled
     permissions:
     - admin
+    krb_principals:
+    - koji/garbagecollector@KOJIDEV.EXAMPLE.COM
   become: no
 
 - name: trashcan tag


### PR DESCRIPTION
Rather than naming the service accounts to match the kerberos principal exactly, name the service accounts with general (non-slash) names, and set the `krb_principals` attribute on each account.

This makes it easier to support Kerberos auth with SSL auth, because we can generate SSL client certificates for these general names.