### PR TITLE
GitHub Actions fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+---
+skip_list:
+  - risky-file-permissions
+  - role-name

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,7 @@
 ---
 skip_list:
   - fqcn-builtins
+  - jinja
+  - name[casing]
   - risky-file-permissions
   - role-name

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,5 @@
 ---
 skip_list:
+  - fqcn-builtins
   - risky-file-permissions
   - role-name

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         export PATH=$PATH:$HOME/.local/bin
         ANSIBLE_LIBRARY=library ansible-lint -v roles/*
   molecule:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Clone koji-ansible

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,17 +41,20 @@ jobs:
     - uses: actions/checkout@v2
     - name: Clone koji-ansible
       run: ./clone-koji-ansible
-    - name: Install molecule
+    - name: Install podman and molecule
       run: |
+        . /etc/os-release
+        echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+        curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
         sudo apt-get update
         sudo apt-get purge ansible
-        sudo apt-get install python3-setuptools
-        pip3 install docker molecule[ansible,docker] --user
+        sudo apt-get install podman python3-setuptools
+        sudo mkdir -p /etc/containers
+        echo 'cgroup_manager="cgroupfs"' | sudo tee /etc/containers/libpod.conf
+        pip3 install molecule[ansible,podman] --user
     - name: Run molecule
       run: |
         export PATH=$PATH:$HOME/.local/bin
-        sudo systemctl start docker
-        sed -i -e 's/podman/docker/g' molecule/centos8/molecule.yml
         export ANSIBLE_MODULE_UTILS=$(pwd)/module_utils
         export ANSIBLE_LIBRARY=$(pwd)/library
         molecule test -s centos8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Run ansible-lint
       run: |
         export PATH=$PATH:$HOME/.local/bin
-        ANSIBLE_LIBRARY=library ansible-lint -x 106 -x 501 -v roles/*
+        ANSIBLE_LIBRARY=library ansible-lint -v roles/*
   molecule:
     runs-on: ubuntu-20.04
     steps:

--- a/roles/activemq/tasks/main.yml
+++ b/roles/activemq/tasks/main.yml
@@ -17,7 +17,7 @@
     checksum: "{{ activemq_checksum }}"
   register: activemq_download
 
-- name: unpack activemq tarball  # noqa 503
+- name: unpack activemq tarball  # noqa no-handler
   unarchive:
     src: "/tmp/apache-activemq-{{ activemq_version }}-bin.tar.gz"
     dest: /opt

--- a/roles/kdc/tasks/kdcproxy.yml
+++ b/roles/kdc/tasks/kdcproxy.yml
@@ -23,6 +23,8 @@
       - "{{ mod_wsgi }}"
       - "{{ python_kdcproxy }}"
     state: present
+  retries: 3
+  delay: 10
 
 - name: copy /etc/httpd/conf.d/kdcproxy.conf
   template:

--- a/roles/koji-builder/tasks/main.yml
+++ b/roles/koji-builder/tasks/main.yml
@@ -11,7 +11,7 @@
     name:
       - python-requests-kerberos
       - python2-kerberos
-    state: latest  # noqa 403
+    state: latest  # noqa package-latest
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
 
 - name: Install Koji builder packages
@@ -39,7 +39,7 @@
     state: link
   register: koji_ca_anchor
 
-- name: trust our new Koji CA system-wide  # noqa 503
+- name: trust our new Koji CA system-wide  # noqa no-handler
   command: update-ca-trust extract
   when: koji_ca_anchor.changed
   notify:

--- a/roles/koji-builder/tasks/main.yml
+++ b/roles/koji-builder/tasks/main.yml
@@ -13,6 +13,8 @@
       - python2-kerberos
     state: latest  # noqa package-latest
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
+  retries: 3
+  delay: 10
 
 - name: Install Koji builder packages
   package:

--- a/roles/koji-ra/tasks/main.yml
+++ b/roles/koji-ra/tasks/main.yml
@@ -11,7 +11,7 @@
     name:
       - python-requests-kerberos
       - python2-kerberos
-    state: latest  # noqa 403
+    state: latest  # noqa package-latest
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
 
 - name: Install Koji utils package

--- a/roles/koji-ra/tasks/main.yml
+++ b/roles/koji-ra/tasks/main.yml
@@ -13,6 +13,8 @@
       - python2-kerberos
     state: latest  # noqa package-latest
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
+  retries: 3
+  delay: 10
 
 - name: Install Koji utils package
   package:

--- a/roles/koji-ssl-admin/tasks/main.yml
+++ b/roles/koji-ssl-admin/tasks/main.yml
@@ -9,7 +9,7 @@
     name: "{{ ssl_admin_prerequisites }}"
     state: present
 
-- name: clone koji-tools.git  # noqa 401
+- name: clone koji-tools.git  # noqa latest[git]
   git:
     repo: https://pagure.io/koji-tools.git
     dest: /usr/local/koji-tools

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -1,18 +1,10 @@
 # https://github.com/fedora-selinux/selinux-policy/pull/1053
-- name: Add yum repository for selinux-policy rabbitmq bug
-  yum_repository:
-    name: selinux-rabbitmq
-    description: work around selinux-rabbitmq bug
-    baseurl: https://fedorapeople.org/~ktdreyer/selinux-rabbitmq/
-    gpgcheck: false
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8
-
-- name: update to latest selinux-policy packages for full rabbitmq support
-  package:
-    name:
-      - selinux-policy
-      - selinux-policy-targeted
-    state: latest  # noqa package-latest
+- name: Allow RabbitMQ to listen on tcp port 15671
+  seport:
+    ports: 15671
+    proto: tcp
+    setype: rabbitmq_port_t
+    state: present
 
 - name: install centos repo for rabbitmq
   package:

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -12,7 +12,7 @@
     name:
       - selinux-policy
       - selinux-policy-targeted
-    state: latest  # noqa 403
+    state: latest  # noqa package-latest
 
 - name: install centos repo for rabbitmq
   package:


### PR DESCRIPTION
Fix the various GitHub Actions failures that have built up over time.

- `ansible-lint` configuration updates
- switch to running `molecule` with `podman` (finally)
- various workarounds for fedorapeople.org connection failures