### PR TITLE
koji-ssl-admin: shallow git clone

### DIFF
--- a/roles/kdc/tasks/kdcproxy.yml
+++ b/roles/kdc/tasks/kdcproxy.yml
@@ -23,7 +23,7 @@
       - "{{ mod_wsgi }}"
       - "{{ python_kdcproxy }}"
     state: present
-  retries: 3
+  retries: 10
   delay: 10
 
 - name: copy /etc/httpd/conf.d/kdcproxy.conf

--- a/roles/koji-builder/tasks/main.yml
+++ b/roles/koji-builder/tasks/main.yml
@@ -13,7 +13,7 @@
       - python2-kerberos
     state: latest  # noqa package-latest
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
-  retries: 3
+  retries: 10
   delay: 10
 
 - name: Install Koji builder packages

--- a/roles/koji-ra/tasks/main.yml
+++ b/roles/koji-ra/tasks/main.yml
@@ -13,7 +13,7 @@
       - python2-kerberos
     state: latest  # noqa package-latest
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
-  retries: 3
+  retries: 10
   delay: 10
 
 - name: Install Koji utils package

--- a/roles/koji-ssl-admin/tasks/main.yml
+++ b/roles/koji-ssl-admin/tasks/main.yml
@@ -9,10 +9,19 @@
     name: "{{ ssl_admin_prerequisites }}"
     state: present
 
+- name: clone koji-tools.git (rhel 7 compatible) # noqa latest[git]
+  git:
+    repo: https://pagure.io/koji-tools.git
+    dest: /usr/local/koji-tools
+    # RHEL 7 has Git v1.8.3.1, so it cannot do shallow clones with "depth: 1"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
+
 - name: clone koji-tools.git  # noqa latest[git]
   git:
     repo: https://pagure.io/koji-tools.git
     dest: /usr/local/koji-tools
+    depth: 1
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int > 7
 
 - name: /etc/pki/koji directory
   file:


### PR DESCRIPTION
RHEL 7 has Git v1.8.3.1, so it doesn't support this.

It works fine on RHEL 8.