### PR TITLE
github: remove apt-key use

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Install podman and molecule
       run: |
         . /etc/os-release
-        echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-        curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+        curl -sS https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | gpg --dearmor | sudo dd of=/etc/apt/trusted.gpg.d/podman.gpg
+        echo "deb [signed-by=/etc/apt/trusted.gpg.d/podman.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
         sudo apt-get update
         sudo apt-get purge ansible
         sudo apt-get install podman python3-setuptools


### PR DESCRIPTION
`apt-key` is deprecated. Use the newer way to obtain the GPG key for the repo.